### PR TITLE
Fix: Fixed Migration Tool Library Import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 # ignore everything in creds and logs
 creds/*
 logs/*
+
+.env

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,7 @@
 import argparse
 
 from setup import setup_logging
-from firebase_migration import migrate_firebase
-from cognito_migration import migrate_cognito
-from auth0_migration import migrate_auth0
+
 
 def main():
     dry_run = False
@@ -13,47 +11,71 @@ def main():
     from_json = False
     json_file_path = ""
 
-
     # General Tool Flags
     parser = argparse.ArgumentParser(
         description="This program assists you in migrating your users and user groups from various services to Descope."
     )
-    parser.add_argument("provider", choices=["firebase", "auth0", "cognito"], help="Specify the service to migrate from")
+    parser.add_argument(
+        "provider",
+        choices=["firebase", "auth0", "cognito"],
+        help="Specify the service to migrate from",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Enable dry run mode")
-    parser.add_argument('--verbose','-v', action='store_true',help='Enable verbose printing for live runs and dry runs')
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable verbose printing for live runs and dry runs",
+    )
 
     # Provider Specific Flags
-    parser.add_argument('--with-passwords', nargs=1, metavar='file-path', help='Run the script with passwords from the specified file')
-    parser.add_argument('--from-json', nargs=1, metavar='file-path', help='Run the script with users from the specified file rather than API')
-    
+    parser.add_argument(
+        "--with-passwords",
+        nargs=1,
+        metavar="file-path",
+        help="Run the script with passwords from the specified file",
+    )
+    parser.add_argument(
+        "--from-json",
+        nargs=1,
+        metavar="file-path",
+        help="Run the script with users from the specified file rather than API",
+    )
+
     args = parser.parse_args()
-    
+
     provider = args.provider
     # General Flags
     if args.dry_run:
-        dry_run=True
-    
+        dry_run = True
+
     if args.verbose:
         verbose = True
-    
+
     # Auth0 Flags
     if args.with_passwords:
         passwords_file_path = args.with_passwords[0]
         with_passwords = True
         # print(f"Running with passwords from file: {passwords_file_path}")
-    
+
     if args.from_json:
         json_file_path = args.from_json[0]
-        from_json=True
+        from_json = True
 
     setup_logging(provider)
 
     if provider == "firebase":
-        migrate_firebase(dry_run,verbose)
+        from firebase_migration import migrate_firebase
+
+        migrate_firebase(dry_run, verbose)
     elif provider == "auth0":
-        migrate_auth0(dry_run,verbose,passwords_file_path,json_file_path)
+        from auth0_migration import migrate_auth0
+
+        migrate_auth0(dry_run, verbose, passwords_file_path, json_file_path)
     elif provider == "cognito":
-        migrate_cognito(dry_run,verbose)
+        from cognito_migration import migrate_cognito
+
+        migrate_cognito(dry_run, verbose)
     else:
         print("Invalid service specified.")
 


### PR DESCRIPTION
## Related Issues

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

When you run it, it tries to initialize the `firebase_migration` even if you don't have a firebase certificate. This resolves that issue.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
